### PR TITLE
Update README.md

### DIFF
--- a/relayer-invalid-tx/README.md
+++ b/relayer-invalid-tx/README.md
@@ -9,7 +9,7 @@ The Relayer does not check for Ethereum Reorgs and might hold invalid data about
 1. Install Python dependencies
 
 ```bash
-pip install SqlAlchemy web3
+pip install SqlAlchemy web3 psycopg2-binary
 ```
 
 2. Make sure you have access to the DigitalOcean PostgreSQL database and a valid SSL certificate on your drive.


### PR DESCRIPTION
The error
```
ModuleNotFoundError: No module named 'psycopg2'
```
appears when running `python db.py`.